### PR TITLE
Taken dates 2026

### DIFF
--- a/_data/dates.csv
+++ b/_data/dates.csv
@@ -1,14 +1,13 @@
 Date,Event
-April 5,Men Alive
-May 14-18,Scrapbooking
-May 23-26, 4th St. Group
-June 1,Fundraiser
+May 6-10,Scrapbooking
+May 22-25,4th St. Group
+May 31,Fundraiser
 June 16-21,Teen Camp
 June 21,Bible Camp Sunday
-June 21-26,Preteen Camp
-July 3-6,Family Reunion
+June 21-25,Preteen Camp
 July 8-11,Family Camp
-August 3-6,4H
-August 7-10, odFm
-August 11-14,Lancaster Covenant
-September 17-21,Quilters Retreat
+July 24-26,Family Reunion
+July 31-August 1,Wedding
+August 3-5,4H
+August 6-9,OdFM
+September 16-20,Quilters Retreat


### PR DESCRIPTION
Update `_data/dates.csv` to reflect the latest 2026 event schedule.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ec1f4cf9-a49c-4635-8021-8288a5751b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec1f4cf9-a49c-4635-8021-8288a5751b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple data-only schedule updates; low risk unless downstream pages rely on exact date strings/formatting.
> 
> **Overview**
> Updates the 2026 event schedule in `_data/dates.csv`, shifting several May/June date ranges earlier and normalizing event names/spacing.
> 
> Adds new late-summer entries (e.g., `Wedding`) and moves `Family Reunion` into July, while adjusting multi-day ranges for events like `4H`, `OdFM`, and `Quilters Retreat`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38c93dec40b34dd2034c88684753447be4778f3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->