### PR TITLE
Update rentals page year to 2026

### DIFF
--- a/rental-rates.md
+++ b/rental-rates.md
@@ -58,7 +58,7 @@ P.O. Box 3 Greenbush, MN 56726
 </div>
 </div>
 
-### Dates already taken for 2025
+### Dates already taken for 2026
 
 <table class="uk-table uk-table-small uk-table-responsive">
     <thead>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line content change in a markdown page with no logic, data, or security impact.
> 
> **Overview**
> Updates the rentals page header from **“Dates already taken for 2025”** to **“Dates already taken for 2026”**, aligning the displayed year with the upcoming booking calendar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a64721d34580a6923c26962644da9f8e3e112f26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->