### PR TITLE
Update fall Scrapbookers date to October 4

### DIFF
--- a/_data/dates.csv
+++ b/_data/dates.csv
@@ -11,3 +11,4 @@ July 31-August 1,Wedding
 August 3-5,4H
 August 6-9,OdFM
 September 16-20,Quilters Retreat
+October 4-8,Scrapbooking

--- a/_data/dates.csv
+++ b/_data/dates.csv
@@ -11,4 +11,4 @@ July 31-August 1,Wedding
 August 3-5,4H
 August 6-9,OdFM
 September 16-20,Quilters Retreat
-October 4-8,Scrapbooking
+September 30-October 4,Scrapbooking


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the 2026 rentals calendar with the rescheduled fall Scrapbookers retreat.

The fall scrapbooking block is listed as **October 4–8** (starting October 4 instead of September 30). The rentals page reads dates from `_data/dates.csv`, so this will appear under “Dates already taken for 2026” on the Rentals page.

## Note

The site already listed a spring Scrapbooking event (May 6–10). This change adds the fall session; there was no existing September 30 entry in the repository.

If the intended end date differs (for example, October 4–7 as in 2018), let us know and we can adjust.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac85e984-a2f2-4922-a345-9cb4657076a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac85e984-a2f2-4922-a345-9cb4657076a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

